### PR TITLE
Improve Yandex playlist scraper

### DIFF
--- a/scripts/yandex_playlist_parser_cookies.py
+++ b/scripts/yandex_playlist_parser_cookies.py
@@ -1,4 +1,5 @@
-"""Parse Yandex Music playlist using saved cookies."""
+#!/usr/bin/env python3
+"""Parse a Yandex Music playlist using saved cookies."""
 
 from playwright.sync_api import sync_playwright
 import os
@@ -39,30 +40,36 @@ def scroll_to_bottom(page, step=1000):
         previous_height = current_height
 
 
-with sync_playwright() as p:
-    browser = p.chromium.launch(headless=False)
-    context = browser.new_context()
-    cookies = parse_netscape_cookies(cookies_file)
-    context.add_cookies(cookies)
-    page = context.new_page()
-    page.goto(url, timeout=60000)
+def main() -> None:
+    """Launch browser, load playlist, and save track titles."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=False)
+        context = browser.new_context()
+        cookies = parse_netscape_cookies(cookies_file)
+        context.add_cookies(cookies)
+        page = context.new_page()
+        page.goto(url, timeout=60000)
 
-    # Ensure all tracks are loaded
-    scroll_to_bottom(page)
+        # Ensure all tracks are loaded
+        scroll_to_bottom(page)
 
-    # Extract only track entries
-    track_labels = page.eval_on_selector_all(
-        '[aria-label^="Track "], [aria-label^="\u0422\u0440\u0435\u043a "]',
-        "els => els.map(e => e.getAttribute('aria-label').replace(/^(Track|\\u0422\\u0440\\u0435\\u043a)\\s*/, ''))"
-    )
-    track_labels = list(dict.fromkeys(track_labels))
+        # Extract only track entries
+        track_labels = page.eval_on_selector_all(
+            '[aria-label^="Track "], [aria-label^="\u0422\u0440\u0435\u043a "]',
+            "els => els.map(e => e.getAttribute('aria-label').replace(/^(Track|\\u0422\\u0440\\u0435\\u043a)\\s*/, ''))"
+        )
+        track_labels = list(dict.fromkeys(track_labels))
 
-    os.makedirs("playlists", exist_ok=True)
-    with open(f"playlists/{output_file}", "w") as f:
-        for track in track_labels:
-            if track:
-                f.write(track.strip() + "\n")
+        os.makedirs('playlists', exist_ok=True)
+        with open(f'playlists/{output_file}', 'w') as f:
+            for track in track_labels:
+                if track:
+                    f.write(track.strip() + '\n')
 
-    print(f"Saved {len(track_labels)} tracks to playlists/{output_file}")
+        print(f'Saved {len(track_labels)} tracks to playlists/{output_file}')
 
-    browser.close()
+        browser.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/yandex_playlist_parser_cookies.py
+++ b/scripts/yandex_playlist_parser_cookies.py
@@ -49,6 +49,10 @@ def main() -> None:
         context.add_cookies(cookies)
         page = context.new_page()
         page.goto(url, timeout=60000)
+        page.wait_for_selector(
+            '[aria-label^="Track "], [aria-label^="\u0422\u0440\u0435\u043a "]',
+            timeout=30000,
+        )
 
         # Ensure all tracks are loaded
         scroll_to_bottom(page)
@@ -68,6 +72,7 @@ def main() -> None:
 
         print(f'Saved {len(track_labels)} tracks to playlists/{output_file}')
 
+        context.close()
         browser.close()
 
 

--- a/scripts/yandex_playlist_parser_cookies.py
+++ b/scripts/yandex_playlist_parser_cookies.py
@@ -1,3 +1,5 @@
+"""Parse Yandex Music playlist using saved cookies."""
+
 from playwright.sync_api import sync_playwright
 import os
 
@@ -25,6 +27,18 @@ def parse_netscape_cookies(filename):
                 })
     return cookies
 
+def scroll_to_bottom(page, step=1000):
+    """Scroll page to the bottom to trigger lazy loading."""
+    previous_height = 0
+    while True:
+        current_height = page.evaluate("document.body.scrollHeight")
+        if current_height == previous_height:
+            break
+        page.evaluate(f"window.scrollBy(0, {step})")
+        page.wait_for_timeout(500)
+        previous_height = current_height
+
+
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=False)
     context = browser.new_context()
@@ -32,18 +46,22 @@ with sync_playwright() as p:
     context.add_cookies(cookies)
     page = context.new_page()
     page.goto(url, timeout=60000)
-    page.wait_for_selector('[aria-label]', timeout=30000)
 
+    # Ensure all tracks are loaded
+    scroll_to_bottom(page)
+
+    # Extract only track entries
     track_labels = page.eval_on_selector_all(
-        '[aria-label]',
-        "elements => elements.map(e => e.getAttribute('aria-label'))"
+        '[aria-label^="Track "], [aria-label^="\u0422\u0440\u0435\u043a "]',
+        "els => els.map(e => e.getAttribute('aria-label').replace(/^(Track|\\u0422\\u0440\\u0435\\u043a)\\s*/, ''))"
     )
     track_labels = list(dict.fromkeys(track_labels))
 
     os.makedirs("playlists", exist_ok=True)
     with open(f"playlists/{output_file}", "w") as f:
         for track in track_labels:
-            f.write(track.strip() + "\n")
+            if track:
+                f.write(track.strip() + "\n")
 
     print(f"Saved {len(track_labels)} tracks to playlists/{output_file}")
 


### PR DESCRIPTION
## Summary
- refine playlist scraping logic
- add auto-scroll to load full playlist
- filter ARIA labels to only capture track titles

## Testing
- `python -m py_compile scripts/yandex_playlist_parser_cookies.py`
- `bash -n scripts/batch_download.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849b92f4a3c8331aae8db75e5e6ec40